### PR TITLE
add flag udp-size

### DIFF
--- a/diverge/diverge.go
+++ b/diverge/diverge.go
@@ -42,6 +42,7 @@ func ip4ToStr(ip uint32) string {
 
 func exchange(m *dns.Msg, dec int) (r *dns.Msg, rtt time.Duration, err error) {
 	client := &dns.Client{}
+	client.UDPSize = uint16(*UDPSize)
 	for _, addr := range upstream[dec-upstreamX] {
 		r, rtt, err = client.Exchange(m, addr)
 		if err != nil {

--- a/diverge/main.go
+++ b/diverge/main.go
@@ -16,6 +16,8 @@ var (
 		"[address]:[port] or [port]")
 	minTTL = flag.Duration("minTTL", 48*time.Hour,
 		"minimum TTL for entries in cache")
+	UDPSize = flag.Uint("udp-size",512,
+		"maximum UDP size of non-EDNS upstream query")
 	redisAddress = flag.String("redis", "",
 		"address of redis server, to cache diverge decisions\n"+
 			"\ta simple in memory cache is used if omitted\n"+


### PR DESCRIPTION
some of upstream return a UDP packet lager than 512 bytes, which cause packet dropping.